### PR TITLE
Update to handle new session id and add keep-alive ping and logout

### DIFF
--- a/client/mock.utilities.js
+++ b/client/mock.utilities.js
@@ -68,6 +68,16 @@ var MockUtilities = /** @class */ (function () {
 		xmlHttp.send(null);
 		return xmlHttp.responseText;
 	};
+	MockUtilities.prototype.logout = function () {
+		browser.executeScript(this.logoutRequest());
+	};
+	MockUtilities.prototype.logoutRequest = function () {
+		var url = this.api_host + '/logout/';
+		var xmlHttp = new XMLHttpRequest();
+		xmlHttp.open('GET', url, false);
+		xmlHttp.send(null);
+		return xmlHttp.responseText;
+	};
 	return MockUtilities;
 }());
 exports.MockUtilities = MockUtilities;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-mock-record",
-  "version": "1.0.0",
+  "version": "1.6.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -154,29 +154,21 @@
       }
     },
     "body-parser": {
-      "version": "1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
-      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "version": "1.18.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.3.tgz",
+      "integrity": "sha1-WykhmP/dVTs6DyDe0FkrlWlVyLQ=",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
         "content-type": "~1.0.4",
         "debug": "2.6.9",
-        "depd": "~1.1.1",
-        "http-errors": "~1.6.2",
-        "iconv-lite": "0.4.19",
+        "depd": "~1.1.2",
+        "http-errors": "~1.6.3",
+        "iconv-lite": "0.4.23",
         "on-finished": "~2.3.0",
-        "qs": "6.5.1",
-        "raw-body": "2.3.2",
-        "type-is": "~1.6.15"
-      },
-      "dependencies": {
-        "qs": {
-          "version": "6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
-          "dev": true
-        }
+        "qs": "6.5.2",
+        "raw-body": "2.3.3",
+        "type-is": "~1.6.16"
       }
     },
     "brace-expansion": {
@@ -421,11 +413,73 @@
         "vary": "~1.1.2"
       },
       "dependencies": {
+        "body-parser": {
+          "version": "1.18.2",
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "~1.6.15"
+          }
+        },
+        "iconv-lite": {
+          "version": "0.4.19",
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        },
         "qs": {
           "version": "6.5.1",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
           "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
           "dev": true
+        },
+        "raw-body": {
+          "version": "2.3.2",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "dev": true,
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          },
+          "dependencies": {
+            "depd": {
+              "version": "1.1.1",
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+              "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
+              "dev": true
+            },
+            "http-errors": {
+              "version": "1.6.2",
+              "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+              "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+              "dev": true,
+              "requires": {
+                "depd": "1.1.1",
+                "inherits": "2.0.3",
+                "setprototypeof": "1.0.3",
+                "statuses": ">= 1.3.1 < 2"
+              }
+            },
+            "setprototypeof": {
+              "version": "1.0.3",
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
+              "dev": true
+            }
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -625,10 +679,13 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
-      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
-      "dev": true
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
     },
     "immediate": {
       "version": "3.0.6",
@@ -1070,41 +1127,15 @@
       "dev": true
     },
     "raw-body": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
-      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
-        "http-errors": "1.6.2",
-        "iconv-lite": "0.4.19",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "depd": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
-          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k=",
-          "dev": true
-        },
-        "http-errors": {
-          "version": "1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
-          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
-          "dev": true,
-          "requires": {
-            "depd": "1.1.1",
-            "inherits": "2.0.3",
-            "setprototypeof": "1.0.3",
-            "statuses": ">= 1.3.1 < 2"
-          }
-        },
-        "setprototypeof": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
-          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ=",
-          "dev": true
-        }
       }
     },
     "readable-stream": {

--- a/server/auth.js
+++ b/server/auth.js
@@ -7,9 +7,15 @@ class Auth {
   constructor() {
     this.http = new Http();
     this._session_id = '';
+    this._domain = '';
+    this.sessionIdCookieName = '_platform-api-endpoints_session';
+    this.sessionIdCookieNameFallback = '_session_id';
+    this.sessionKeepAliveEndpoint = '/auth/hasSession.json';
+    this.sessionKeepAliveInterval = 20;
+    this.sessionKeepAliveTimer = null;
   }
 
-  login(user, domain) {
+  login(user, domain, keepAlive = true) {
     return new Promise(resolve => {
       this.http.post(
         domain + '/idp/auth',
@@ -23,7 +29,7 @@ class Auth {
         }
 
         const SAMLResponse = data.body.split(samlInputStart)[1].split(samlInputEnd)[0].replace(`"`,``).trim();
-        
+
         this.http.post(
           domain + '/auth/consume',
           {
@@ -31,8 +37,18 @@ class Auth {
             'relaystate': ''
           }
         ).then(data => {
-          this._session_id = data.headers['set-cookie'].find(cookie => cookie.indexOf('_session_id') > -1);
-          console.log('Successfully logged in as: ' + user + ', _session_id: ' + this._session_id);
+          this._session_id = data.headers['set-cookie'].find(cookie => cookie.indexOf(this.sessionIdCookieName) > -1);
+          if (!this._session_id) {
+            this._session_id = data.headers['set-cookie'].find(cookie => cookie.indexOf(this.sessionIdCookieNameFallback) > -1);
+          }
+          if (!this._session_id) {
+            console.log('ERROR: Session ID Cookie not found: ', data.headers['set-cookie']);
+          }
+          console.log('Successfully logged in as: ' + user + ', ' + this.sessionIdCookieName + ': ' + this._session_id);
+          if (keepAlive) {
+            this.http.config = {domain: domain};
+            this.initKeepAlive();
+          }
           resolve(this._session_id);
         }, () => {
           console.log('Error logging in!');
@@ -42,9 +58,55 @@ class Auth {
     });
   }
 
+  logout() {
+    return new Promise(resolve => {
+      if (this.sessionKeepAliveTimer) {
+        clearTimeout(this.sessionKeepAliveTimer);
+        this.sessionKeepAliveTimer = null;
+      }
+      this.http.get(
+        {url: '/auth/SSOLogout?relaystate=http://localhost:4200'},
+        this._session_id
+      ).then(
+        resp => {
+          console.log('Successfully Logged Out');
+          resolve();
+        },
+        () => resolve()
+      );
+    });
+  }
+
   getUser(path) {
     path = path.split('/');
     return path[2];
+  }
+
+  setSessionIdCookieName(name) {
+    this.sessionIdCookieName = name;
+  }
+
+  setSessionKeepAliveEndpoint(endpoint) {
+    this.sessionKeepAliveEndpoint = endpoint;
+  }
+
+  setSessionKeepAliveInterval(interval) {
+    this.sessionKeepAliveInterval = interval;
+  }
+
+  initKeepAlive() {
+    this.http.get(
+      {url: this.sessionKeepAliveEndpoint},
+      this._session_id
+    ).then((resp) => {
+      const status = resp && resp.body && resp.body.data;
+      if (status) {
+        console.log('Session Keep-Alive Ping Successful: ', status);
+        this.sessionKeepAliveTimer = setTimeout(() => this.initKeepAlive(), this.sessionKeepAliveInterval * 1000);
+      } else {
+        console.log('Error: Session Keep-Alive Ping Failed: ', resp);
+      }
+    });
   }
 }
 

--- a/server/http.js
+++ b/server/http.js
@@ -9,6 +9,7 @@ class Http {
 
     return new Promise((resolve, reject) => {
       let headers = this.setRequestHeaders(req.headers, _session_id);
+      console.log('REQUEST: ', this.config.domain + req.url);
 
       this.http.get(
       {

--- a/server/request.handler.js
+++ b/server/request.handler.js
@@ -25,7 +25,7 @@ class RequestHandler {
     if (this.config.cors) {
       res = this.http.setCorsHeaders(req, res);
     }
-  
+
     if (this.shouldMock(req.path)) {
 
       this.mock.setRequestAsMocked(req.path, req.body, req.headers);
@@ -42,7 +42,7 @@ class RequestHandler {
       res.status(200).send(true);
 
     } else if (this.shouldClearMocks(req.path)) {
-  
+
       this.mock.clearMockedRequests();
       this.auth._session_id = '';
       this.setDefaultDomain();
@@ -52,6 +52,12 @@ class RequestHandler {
     } else if (this.shouldLogin(req.path)) {
 
       this.auth.login( this.auth.getUser(req.path), this.config.domain ).then(_session_id => {
+        res.status(200).send(true);
+      });
+
+    } else if (this.shouldLogout(req.path)) {
+
+      this.auth.logout().then(() => {
         res.status(200).send(true);
       });
 
@@ -114,6 +120,10 @@ class RequestHandler {
     return !!( path.includes('/login/') );
   }
 
+  shouldLogout(path) {
+    return !!( path.includes('/logout/') );
+  }
+
   shouldSetDomain(path) {
     return !!( path.includes('/domain/') );
   }
@@ -121,7 +131,7 @@ class RequestHandler {
   shouldSetContext(path) {
     return !!( path.includes('/context/') );
   }
-  
+
   refreshConfigs() {
     this.http = new Http(this.config);
     this.recorder = new Record(this.config);


### PR DESCRIPTION
This PR updates the mock utilities that is used by platform-ui-2 E2E tests to handle the new server-side session management, as well as adding a keep-alive ping and logout method.