### PR TITLE
update check

### DIFF
--- a/server/auth.js
+++ b/server/auth.js
@@ -24,7 +24,7 @@ class Auth {
         }
       ).then(data => {
 
-        if (!data) {
+        if (!(data && data.body)) {
           return resolve();
         }
 


### PR DESCRIPTION
I was seeing this error when running E2E tests:
```
(node:33832) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'split' of undefined
    at http.post.then.data (/Users/mharting/sites/platform-ui-2/node_modules/angular-mock-record/server/auth.js:31:64)
    at process._tickCallback (internal/process/next_tick.js:68:7)
(node:33832) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block, or by rejecting a promise which was not handled with .catch(). (rejection id: 1)
(node:33832) [DEP0018] DeprecationWarning: Unhandled promise rejections are deprecated. In the future, promise rejections that are not handled will terminate the Node.js process with a non-zero exit code.
```
Updating this check will prevent this error.